### PR TITLE
Fix incorrect aspect ratio of preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /build
 /captures
 .externalNativeBuild
+mobilevision-pipeline/build
+sample/build
+.idea

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,6 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">

--- a/mobilevision-pipeline/src/main/java/online/devliving/mobilevisionpipeline/camera/CameraSourcePreview.java
+++ b/mobilevision-pipeline/src/main/java/online/devliving/mobilevisionpipeline/camera/CameraSourcePreview.java
@@ -70,7 +70,6 @@ public class CameraSourcePreview extends ViewGroup {
 
         if (mCameraSource != null) {
             mStartRequested = true;
-            requestLayout();
             startIfReady();
         }
     }
@@ -100,6 +99,7 @@ public class CameraSourcePreview extends ViewGroup {
             mCameraSource.start(mSurfaceView.getHolder());
             updateOverlay();
             mStartRequested = false;
+            requestLayout(); // mCameraSource.getPreviewSize() is available for updateChildSizeFor...()
         }
     }
 


### PR DESCRIPTION
In my test phone (Huawei Y9) when i open the sample application the picture shown is distorted, highest than normal in landscape.  You can see the difference when you go on background and back, which makes the correct sizing.

The problem was that when CameraSourcePreview.onLayout() is called for the first time, and it calls updateChildSizeForFill(), mCameraSource.getPreviewSize() returns null and the size 320x240 is used, instead of the correct one, 1920x1080 in my case.

Moving the requestLayout() call fixes the issue.